### PR TITLE
Added support for macOS/Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ endif
 # Initialize bin directory structure
 .PHONY: init
 init:
+ifeq ($(OS), Windows_NT)
 	- MKDIR $(BINDIR)
 	- MKDIR $(BINDIR)\core
 	- MKDIR $(BINDIR)\math
@@ -134,9 +135,19 @@ init:
 	- MKDIR $(BINDIR)\lights
 	- MKDIR $(BINDIR)\res
 	- MKDIR $(BINDIR)\3rdparty
-ifeq ($(OS), Windows_NT)
 	- XCOPY /E res $(BINDIR)\res
 else
-	- cp res $(BINDIR)\res
+	- MKDIR $(BINDIR)
+	- MKDIR $(BINDIR)/core
+	- MKDIR $(BINDIR)/math
+	- MKDIR $(BINDIR)/shapes
+	- MKDIR $(BINDIR)/cameras
+	- MKDIR $(BINDIR)/accelerators
+	- MKDIR $(BINDIR)/renderers
+	- MKDIR $(BINDIR)/materials
+	- MKDIR $(BINDIR)/lights
+	- MKDIR $(BINDIR)/res
+	- MKDIR $(BINDIR)/3rdparty
+	- cp -r res $(BINDIR)
 endif
 	@echo "Initialization done."

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,6 @@ LD = $(ENV)
 # Include directories
 CXXINCS += -I./include/
 
-ifneq ($(OS), Windows_NT)
-	ifeq ($(shell uname -s), Darwin)
-		LDFLAGS = -Wl -m64
-	else
-		LDFLAGS = -Wl,--as-needed -m64
-	endif
-endif
-
 # Linker flags
 ifneq ($(OS), Windows_NT)
 	ifeq ($(shell uname -s), Darwin)

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,37 @@ LD = $(ENV)
 # Include directories
 CXXINCS += -I./include/
 
+ifneq ($(OS), Windows_NT)
+	ifeq ($(shell uname -s), Darwin)
+		LDFLAGS = -Wl -m64
+	else
+		LDFLAGS = -Wl,--as-needed -m64
+	endif
+endif
+
 # Linker flags
-LDFLAGS = -Wl,--as-needed -m64
+ifneq ($(OS), Windows_NT)
+	ifeq ($(shell uname -s), Darwin)
+		LDFLAGS = -Wl -m64
+	endif
+else
+	LDFLAGS = -Wl,--as-needed -m64
+endif
 
 # Linker libs, lua might be -llua or -llua53 or -lluaXX, XX being your installed lua version
 ifeq ($(OS), Windows_NT)
   LDLIBS = -L./lib/ -lmingw32 -lSDL2main
 endif
-LDLIBS += -lSDL2 -llua -lpthread -lstdc++ -lm -static-libgcc -static-libstdc++
+
+LDLIBS += -lSDL2 -llua -lpthread -lstdc++ -lm
+
+ifneq ($(OS), Windows_NT)
+	ifneq ($(shell uname -s), Darwin)
+		LDLIBS += -static-libgcc -static-libstdc++
+	endif
+else
+	LDLIBS += -static-libgcc -static-libstdc++
+endif
 
 # Compiler
 CXX = $(ENV)

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -6,10 +6,6 @@
 #include "../macros.h"
 #include "../math/mat4.h"
 
-#define OS_WINDOWS 	(defined(_WIN64) || defined(_WIN32) ||  defined(__WIN32__) || defined(__TOS_WIN__) || defined(__CYGWIN__) || defined(__CYGWIN32) || defined(__MINGW32__) || defined(__BORLANDC__) || defined(__WINDOWS__))
-#define OS_MACOS    (defined(macintosh) || defined(Macintosh) || defined(__APPLE__) || defined(__MACH__))
-#define OS_LINUX    (defined(__linux__) || defined(__linux))
-
 namespace mirage
 {
 

--- a/src/core/display.cpp
+++ b/src/core/display.cpp
@@ -6,6 +6,10 @@
 #include "../macros.h"
 #include "../math/mat4.h"
 
+#define OS_WINDOWS 	(defined(_WIN64) || defined(_WIN32) ||  defined(__WIN32__) || defined(__TOS_WIN__) || defined(__CYGWIN__) || defined(__CYGWIN32) || defined(__MINGW32__) || defined(__BORLANDC__) || defined(__WINDOWS__))
+#define OS_MACOS    (defined(macintosh) || defined(Macintosh) || defined(__APPLE__) || defined(__MACH__))
+#define OS_LINUX    (defined(__linux__) || defined(__linux))
+
 namespace mirage
 {
 
@@ -119,11 +123,20 @@ namespace mirage
 		m_isSavingImage = true;
 		FILE *f;
 
+#if OS_WINDOWS
 		if (fopen_s(&f, filename.c_str(), "w"))
 		{
 			ERR("Display: Writing image to a .ppm file failed... fopen returned NULL.");
 			return;
 		}
+#elif OS_MACOS || OS_LINUX
+		f = fopen(filename.c_str(), "w");
+		if (f != NULL)
+		{
+			ERR("Display: Writing image to a .ppm file failed... fopen returned NULL.");
+			return;
+		}
+#endif
 
 		fprintf(f, "P3\n%d %d\n%d\n", m_width, m_height, 255);
 		for (size_t i = 0; i < m_width * m_height; i++)

--- a/src/macros.h
+++ b/src/macros.h
@@ -15,4 +15,9 @@
 #define DELETE(a) if( (a) != NULL ) delete (a); (a) = NULL;
 #define DELETEA(a) if ( (a) != NULL ) delete[] (a); (a) = NULL;
 
+// Operating System Macros
+#define OS_WINDOWS  (defined(_WIN64) || defined(_WIN32) ||  defined(__WIN32__) || defined(__TOS_WIN__) || defined(__CYGWIN__) || defined(__CYGWIN32) || defined(__MINGW32__) || defined(__BORLANDC__) || defined(__WINDOWS__))
+#define OS_MACOS    (defined(macintosh) || defined(Macintosh) || defined(__APPLE__) || defined(__MACH__))
+#define OS_LINUX    (defined(__linux__) || defined(__linux))
+
 #endif // MACROS_H


### PR DESCRIPTION
- Added pragmas in `display.cpp` for OS detection
  - Uses `fopen` instead of `fopen_s` for macOS & Linux
- Makefile changed to support clang (macOS)
  - Removed unsupported compiler/linker flags for clang
